### PR TITLE
【Binary to Image】修正某处链接格式，同时完善目录中对应标题

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -8,7 +8,7 @@
 - [创建任务计算圆周率](./job-quick-start.md)
 - [设置弹性伸缩](./hpa.md)
 - [Source to Image：无需 Dockerfile 发布应用](./source-to-image.md)
-- [Binary to Image](./b2i-war/b2i-war.md)
+- [Binary to Image：无需 Dockerfile 发布应用](./b2i-war/b2i-war.md)
 - [基于 Spring Boot 项目构建流水线](./devops-online.md)
 - [图形化构建流水线](./jenkinsfile-out-of-scm.md)
 - [Bookinfo 微服务的灰度发布示例](./bookinfo-canary.md)

--- a/src/b2i-war/b2i-war.md
+++ b/src/b2i-war/b2i-war.md
@@ -163,7 +163,7 @@
 
 4. 在**构建设置**页面，请提供以下相应信息，然后点击**创建**。
 
-   **上传制品**：下载 [b2i-binary](https://github.com/kubesphere/tutorial/raw/master/tutorial 4 - s2i-b2i/b2i-binary) 并上传至 KubeSphere。
+   **上传制品**：下载 [b2i-binary](https://github.com/kubesphere/tutorial/raw/master/tutorial 4 - s2i-b2i/b2i-binary)并上传至 KubeSphere。
 
    **构建环境**：选择 **kubesphere/s2i-binary:v3.2.0**。
 

--- a/src/b2i-war/b2i-war.md
+++ b/src/b2i-war/b2i-war.md
@@ -163,7 +163,7 @@
 
 4. 在**构建设置**页面，请提供以下相应信息，然后点击**创建**。
 
-   **上传制品**：下载 [b2i-binary](https://github.com/kubesphere/tutorial/raw/master/tutorial 4 - s2i-b2i/b2i-binary)并上传至 KubeSphere。
+   **上传制品**：下载 [b2i-binary](https://github.com/kubesphere/tutorial/raw/master/tutorial%204%20-%20s2i-b2i/b2i-binary)并上传至 KubeSphere。
 
    **构建环境**：选择 **kubesphere/s2i-binary:v3.2.0**。
 


### PR DESCRIPTION
update: src/b2i-war.md 链接中添加了空格对应的转义符，使之显示正确
update: src/SUMMARY.md 将分节标题 【Binary to Image】 改为 【Binary to Image：无需 Dockerfile 发布应用】，使其和前者保持一致